### PR TITLE
H-Score fix

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -24,9 +24,9 @@ jobs:
       matrix:
         config:
           - {os: windows-latest, r: 'release'}
-          - {os: windows-latest, r: '4.0.5'}
+          - {os: windows-latest, r: '4.1.0'}
           - {os: macOS-latest, r: 'release'}
-          - {os: macOS-10.15, r: '4.0.5'}
+          - {os: macOS-10.15, r: '4.1.0'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Authors@R: c(
 Copyright: Akoya Biosciences
 Description: Creates diagnostic and summary reports from inForm data.
 Language: en-US
-Depends: R (>= 4.0.0)
+Depends: R (>= 4.1.0)
 License: Zlib | file LICENSE
 Encoding: UTF-8
 LazyData: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: phenoptrReports
 Title: Create reports using Phenoptics data
 Version: 0.3.3.9001
-Date: 2023-11-04
+Date: 2023-11-06
 Authors@R: c(
     person("Kent S", "Johnson", role = c("aut", "cre"),
             email = "kjohnson@akoyabio.com"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: phenoptrReports
 Title: Create reports using Phenoptics data
-Version: 0.3.3
+Version: 0.3.3.9000
 Date: 2022-01-11
 Authors@R: c(
     person("Kent S", "Johnson", role = c("aut", "cre"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,12 +1,14 @@
 Package: phenoptrReports
 Title: Create reports using Phenoptics data
-Version: 0.3.3.9000
-Date: 2022-01-11
+Version: 0.3.3.9001
+Date: 2023-11-04
 Authors@R: c(
     person("Kent S", "Johnson", role = c("aut", "cre"),
-           email = "kjohnson@akoyabio.com"),
+            email = "kjohnson@akoyabio.com"),
     person("Carla", "Coltharp", role="ctb"),
-    person("Akoya Biosciences", role=c("cph", "fnd")))
+    person("Akoya Biosciences", role=c("cph", "fnd")),
+    person("Christian", "Rickert", role="ctb",
+            email = "christian.rickert@cuanschutz.edu"))
 Copyright: Akoya Biosciences
 Description: Creates diagnostic and summary reports from inForm data.
 Language: en-US

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # phenoptrReports 0.3.3.9000
 
+- Update the minimum R version to 4.1.0 to match phenoptr requirement
+
 # phenoptrReports 0.3.3
 **2022-01-11**
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# phenoptrReports 0.3.3.9000
+
 # phenoptrReports 0.3.3
 **2022-01-11**
 

--- a/R/compute_density.R
+++ b/R/compute_density.R
@@ -43,8 +43,7 @@ compute_density_from_cell_summary =
   if (any(startsWith(names(summary_data), 'Phenotype')))
     # This selects rows with 'All' in all phenotype columns
     summary_data = summary_data %>%
-      dplyr::filter(
-        dplyr::across(dplyr::starts_with('Phenotype'), ~.x=='All'))
+      dplyr::filter(if_all(dplyr::starts_with('Phenotype'), ~.x=='All'))
 
   # Manufacture Tissue Category Area if not present
   summary_data = ensure_tissue_category_area(summary_data)

--- a/R/distance_helpers.R
+++ b/R/distance_helpers.R
@@ -134,7 +134,9 @@ nearest_neighbor_summary_single_impl = function(csd, phenotypes,
 
   # All pairs of phenotypes. Order matters so this will include both
   # (a, b) and (b, a).
-  pheno_pairs = purrr::cross2(names(phenotypes), names(phenotypes))
+  pheno_pairs <- tidyr::expand_grid(A = names(phenotypes), B = names(phenotypes)) %>%
+    split(seq_len(nrow(.))) %>% 
+    map(~ .x %>% as.list())
 
   # Helper functions for computing a bunch of summary stats on distances
   # Compute summary stats for a single dataset and all pheno_pairs
@@ -292,8 +294,10 @@ count_within_summary_impl = function(csd, phenotypes, radii,
 
   # All pairs of phenotypes as a list of vectors.
   # Order matters so this will include both (a, b) and (b, a).
-  pheno_pairs = purrr::cross2(names(phenotypes), names(phenotypes)) %>%
-    purrr::map(unlist)
+  pheno_pairs <- expand_grid(A = names(phenotypes), B = names(phenotypes)) %>%
+    split(seq_len(nrow(.))) %>% 
+    map(~ unlist(.x))
+
 
   # Prep data - nest csd by field and .by
   if (.by == field_col)

--- a/R/excel_helpers.R
+++ b/R/excel_helpers.R
@@ -535,9 +535,9 @@ outline_cells = function(wb, sheet_name, rows, cols) {
                      stack=TRUE)
 }
 
-# Remove " (xx xx) Mean" from strings
+# Remove " (xx xx) Mean" from strings, cast symbols to strings before use
 remove_marker_mean = function(s) {
-  stringr::str_remove_all(s, ' \\(.*?\\) Mean')
+  stringr::str_remove_all(as.character(s), ' \\(.*?\\) Mean')
 }
 
 # Create valid Excel worksheet tab names from the given strings

--- a/R/positivity.R
+++ b/R/positivity.R
@@ -180,13 +180,16 @@ compute_h_score = function(csd, measure, tissue_categories, thresholds,
     dplyr::select(!!.by, `Tissue Category`, !!measure) %>%
     dplyr::filter(`Tissue Category` %in% tissue_categories)
 
-  # Score each cell and summarize
+  # Score each cell compartment and summarize
   d = d %>%
     dplyr::mutate(score = dplyr::case_when(
+    # score numeric values
+    !!measure >= thresholds[3] ~ 3,
+    !!measure >= thresholds[2] ~ 2,
+    !!measure >= thresholds[1] ~ 1,
     !!measure < thresholds[1] ~ 0,
-    !!measure < thresholds[2] ~ 1,
-    !!measure < thresholds[3] ~ 2,
-    TRUE ~ 3)) %>%
+    # ignore non-numeric values ("#N/A")
+    .default = NULL)) %>%
     dplyr::group_by(!!.by, `Tissue Category`) %>%
     dplyr::summarize(
       `Count of 0+` = sum(score==0),

--- a/R/positivity.R
+++ b/R/positivity.R
@@ -189,6 +189,8 @@ compute_h_score = function(csd, measure, tissue_categories, thresholds,
     !!measure >= thresholds[1] ~ 1,
     !!measure < thresholds[1] ~ 0,
     # ignore non-numeric values ("#N/A")
+    #   inForm is scoring missing values as `0+`
+    #   phenoptrReports was scoring missing values as `3+`
     .default = NA)) %>%
     dplyr::group_by(!!.by, `Tissue Category`) %>%
     dplyr::summarize(
@@ -197,7 +199,9 @@ compute_h_score = function(csd, measure, tissue_categories, thresholds,
       `Count of 1+` = sum(score==1, na.rm = TRUE),
       `Count of 2+` = sum(score==2, na.rm = TRUE),
       `Count of 3+` = sum(score==3, na.rm = TRUE),
-      Total = dplyr::n()
+      # total percentages include numeric values only
+      #   inForm reports `Number of Cells`, not measurements, across all tissues
+      Total = `Count of 0+` + `Count of 1+` + `Count of 2+` + `Count of 3+`
     ) %>%
     dplyr::ungroup()
 

--- a/R/positivity.R
+++ b/R/positivity.R
@@ -187,11 +187,11 @@ compute_h_score = function(csd, measure, tissue_categories, thresholds,
     !!measure >= thresholds[3] ~ 3,
     !!measure >= thresholds[2] ~ 2,
     !!measure >= thresholds[1] ~ 1,
-    !!measure < thresholds[1] ~ 0,
+    !!measure < thresholds[1] ~ 0),
     # ignore non-numeric values ("#N/A")
     #   inForm is scoring missing values as `0+`
     #   phenoptrReports was scoring missing values as `3+`
-    .default = NA)) %>%
+    .default = NA) %>%
     dplyr::group_by(!!.by, `Tissue Category`) %>%
     dplyr::summarize(
       # summarize only numeric values

--- a/R/positivity.R
+++ b/R/positivity.R
@@ -135,9 +135,11 @@ compute_h_score_from_score_data = function(csd, score_path,
 
   result = compute_h_score(csd, measure, tissue_categories, thresholds, .by)
 
+  # H-Scores for rare phenotypes missing any counts are populated from scratch,
+  # corresponding NA values are later reported as "#N/A" values in Excel
   if (nrow(result) != nrow(full_combos)) {
     # Add in missing combinations
-    fill = rep(0, 5) %>% rlang::set_names(names(result)[3:7]) %>% as.list()
+    fill = rep(NA, 5) %>% rlang::set_names(names(result)[3:7]) %>% as.list()
     result = full_combos %>%
       dplyr::left_join(result) %>%
       tidyr::replace_na(replace = fill) %>%

--- a/R/positivity.R
+++ b/R/positivity.R
@@ -189,13 +189,14 @@ compute_h_score = function(csd, measure, tissue_categories, thresholds,
     !!measure >= thresholds[1] ~ 1,
     !!measure < thresholds[1] ~ 0,
     # ignore non-numeric values ("#N/A")
-    .default = NULL)) %>%
+    .default = NA)) %>%
     dplyr::group_by(!!.by, `Tissue Category`) %>%
     dplyr::summarize(
-      `Count of 0+` = sum(score==0),
-      `Count of 1+` = sum(score==1),
-      `Count of 2+` = sum(score==2),
-      `Count of 3+` = sum(score==3),
+      # summarize only numeric values
+      `Count of 0+` = sum(score==0, na.rm = TRUE),
+      `Count of 1+` = sum(score==1, na.rm = TRUE),
+      `Count of 2+` = sum(score==2, na.rm = TRUE),
+      `Count of 3+` = sum(score==3, na.rm = TRUE),
       Total = dplyr::n()
     ) %>%
     dplyr::ungroup()

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,4 +1,9 @@
 library(testthat)
 library(phenoptrReports)
+library(rstudioapi)
 
+# set path to current script directory
+setwd(dirname(getSourceEditorContext()$path))
+
+# run test script with test data
 test_check("phenoptrReports")


### PR DESCRIPTION
This branch is based on the upstream `9000` (development) branch and provides compatibility with `inForm 2.6` or later. The fixes address a minor inconsistency with H-Score calculations that @himsr-lab has encountered during its analysis: Cells with missing compartments chosen for H-Score calculation were not excluded from the H-Score calculation.

I would like to thank @AB-Kent and @akoyabio for all the fantastic work that went into `phenoptr` & `phenoptrReports` and for all their first-class support!